### PR TITLE
Databricks cli updates

### DIFF
--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.azure/devops-pipelines/{{cookiecutter.project_name}}-bundle-cicd.yml
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.azure/devops-pipelines/{{cookiecutter.project_name}}-bundle-cicd.yml
@@ -49,7 +49,7 @@ stages:
 
     # Validate bundle to be deployed to the staging workspace
     - script: |
-        databricks bundle validate -e staging  
+        databricks bundle validate -t staging  
       workingDirectory: {{cookiecutter.project_name_alphanumeric_underscore}}
       displayName: 'Validate bundle for staging environment'
       env:
@@ -77,7 +77,7 @@ stages:
 
     # Validate bundle to be deployed to the staging workspace
     - script: |
-        databricks bundle validate -e prod  
+        databricks bundle validate -t prod  
       workingDirectory: {{cookiecutter.project_name_alphanumeric_underscore}}
       displayName: Validate bundle for staging environment 
       env:
@@ -118,7 +118,7 @@ stages:
 
     # Validate bundle to be deployed to the Staging workspace
     - script: |
-        databricks bundle validate -e staging  
+        databricks bundle validate -t staging  
       workingDirectory: {{cookiecutter.project_name_alphanumeric_underscore}}
       displayName: Validate bundle for staging environment 
       env:
@@ -128,7 +128,7 @@ stages:
 
     # Deploy bundle to Staging workspace
     - script: |
-        databricks bundle deploy -e staging
+        databricks bundle deploy -t staging
       workingDirectory: {{cookiecutter.project_name_alphanumeric_underscore}}
       displayName: 'Deploy bundle to staging environment'
       env:
@@ -169,7 +169,7 @@ stages:
 
     # Validate bundle to be deployed to the prod workspace
     - script: |
-        databricks bundle validate -e prod  
+        databricks bundle validate -t prod  
       workingDirectory: {{cookiecutter.project_name_alphanumeric_underscore}}
       displayName: Validate bundle for prod environment 
       env:
@@ -179,7 +179,7 @@ stages:
 
     # Deploy bundle to prod workspace
     - script: |
-        databricks bundle deploy -e prod
+        databricks bundle deploy -t prod
       workingDirectory: {{cookiecutter.project_name_alphanumeric_underscore}}
       displayName: Deploy bundle to prod environment
       env:

--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.azure/devops-pipelines/{{cookiecutter.project_name}}-tests-ci.yml
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.azure/devops-pipelines/{{cookiecutter.project_name}}-tests-ci.yml
@@ -76,7 +76,7 @@ jobs:
 
     # Validate bundle to be deployed to the staging workspace
     - script: |
-        databricks bundle validate -e test  
+        databricks bundle validate -t test  
       workingDirectory: {{cookiecutter.project_name_alphanumeric_underscore}}
       displayName: Validate bundle for test environment in staging workspace 
       env:
@@ -86,7 +86,7 @@ jobs:
 
     # Deploy bundle to staging workspace
     - script: |
-        databricks bundle deploy -e test
+        databricks bundle deploy -t test
       workingDirectory: {{cookiecutter.project_name_alphanumeric_underscore}}
       displayName: Deploy bundle to test environment in staging workspace
       env:
@@ -97,7 +97,7 @@ jobs:
     {% if cookiecutter.framework == "fs" %}
     # Run Feature Engineering Workflow for Test Environment in Staging Workspace
     - script: |
-        databricks bundle run write_feature_table_job -e test
+        databricks bundle run write_feature_table_job -t test
       workingDirectory: {{cookiecutter.project_name_alphanumeric_underscore}}
       displayName: Run Feature Engineering Workflow for Test Environment in Staging Workspace
       env:
@@ -108,7 +108,7 @@ jobs:
     
     # Run model_training_job defined in bundle in the staging workspace
     - script: |
-        databricks bundle run model_training_job -e test
+        databricks bundle run model_training_job -t test
       workingDirectory: {{cookiecutter.project_name_alphanumeric_underscore}}
       displayName: Run training workflow for test environment in staging workspace
       env:

--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.github/workflows/{{cookiecutter.project_name}}-bundle-cd-prod.yml
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.github/workflows/{{cookiecutter.project_name}}-bundle-cd-prod.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Validate Bundle For Prod Environment
         id: validate
         run: |
-          databricks bundle validate -e prod
+          databricks bundle validate -t prod
       - name: Deploy Bundle to Prod Environment
         id: deploy
         run: |
-          databricks bundle deploy -e prod
+          databricks bundle deploy -t prod

--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.github/workflows/{{cookiecutter.project_name}}-bundle-cd-staging.yml
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.github/workflows/{{cookiecutter.project_name}}-bundle-cd-staging.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Validate Bundle For Staging Environment
         id: validate
         run: |
-          databricks bundle validate -e staging
+          databricks bundle validate -t staging
       - name: Deploy Bundle to Staging Environment
         id: deploy
         run: |
-          databricks bundle deploy -e staging
+          databricks bundle deploy -t staging

--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.github/workflows/{{cookiecutter.project_name}}-bundle-ci.yml
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.github/workflows/{{cookiecutter.project_name}}-bundle-ci.yml
@@ -44,7 +44,7 @@ jobs:
           ARM_CLIENT_SECRET: {% raw %}${{ env.STAGING_ARM_CLIENT_SECRET }}{% endraw %}
           {%- endif %}
         run: |
-          databricks bundle validate -e staging > ../validate_output.txt
+          databricks bundle validate -t staging > ../validate_output.txt
       - name: Create Comment with Bundle Configuration
         uses: actions/github-script@v6
         id: comment
@@ -88,7 +88,7 @@ jobs:
           ARM_CLIENT_SECRET: {% raw %}${{ env.PROD_ARM_CLIENT_SECRET }}{% endraw %}
           {%- endif %}
         run: |
-          databricks bundle validate -e prod > ../validate_output.txt
+          databricks bundle validate -t prod > ../validate_output.txt
       - name: Create Comment with Bundle Configuration
         uses: actions/github-script@v6
         id: comment

--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.github/workflows/{{cookiecutter.project_name}}-run-tests-fs.yml
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.github/workflows/{{cookiecutter.project_name}}-run-tests-fs.yml
@@ -50,16 +50,16 @@ jobs:
       - name: Validate Bundle For Test Environment in Staging Workspace
         id: validate
         run: |
-          databricks bundle validate -e test
+          databricks bundle validate -t test
       - name: Deploy Bundle to Test Environment in Staging Workspace
         id: deploy
         run: |
-          databricks bundle deploy -e test
+          databricks bundle deploy -t test
       - name: Run Feature Engineering Workflow for Test Environment in Staging Workspace
         id: feature_engineering
         run: |
-          databricks bundle run write_feature_table_job -e test
+          databricks bundle run write_feature_table_job -t test
       - name: Run Training Workflow for Test Environment in Staging Workspace
         id: training
         run: |
-          databricks bundle run model_training_job -e test
+          databricks bundle run model_training_job -t test

--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.github/workflows/{{cookiecutter.project_name}}-run-tests.yml
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.github/workflows/{{cookiecutter.project_name}}-run-tests.yml
@@ -45,12 +45,12 @@ jobs:
       - name: Validate Bundle For Test Environment in Staging Workspace
         id: validate
         run: |
-          databricks bundle validate -e test
+          databricks bundle validate -t test
       - name: Deploy Bundle to Test Environment in Staging Workspace
         id: deploy
         run: |
-          databricks bundle deploy -e test
+          databricks bundle deploy -t test
       - name: Run Training Workflow for Test Environment in Staging Workspace
         id: training
         run: |
-          databricks bundle run model_training_job -e test
+          databricks bundle run model_training_job -t test

--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{cookiecutter.project_name_alphanumeric_underscore}}/databricks-resources/ml-artifacts-resource.yml
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{cookiecutter.project_name_alphanumeric_underscore}}/databricks-resources/ml-artifacts-resource.yml
@@ -2,25 +2,25 @@
 environments:
   dev:
     resources:
-      models:
+      model-registry:
         model:
           description: MLflow registered model for the "{{cookiecutter.project_name}}" ML Project for ${bundle.environment} environment.
 
   test:
     resources:
-      models:
+      model-registry:
         model:
           description: MLflow registered model for the "{{cookiecutter.project_name}}" ML Project for ${bundle.environment} environment.
 
   staging:
     resources:
-      models:
+      model-registry:
         model:
           description: MLflow registered model for the "{{cookiecutter.project_name}}" ML Project for ${bundle.environment} environment.
 
   prod:
     resources:
-      models:
+      model-registry:
         model:
           description: |
             MLflow registered model for the "{{cookiecutter.project_name}}" ML Project. See the corresponding [Git repo]($#{var.git_repo_url}) for details on the project.
@@ -38,7 +38,7 @@ permissions: &permissions
 
 # Defines model and experiments
 resources:
-  models:
+  model-registry:
     model:
       name: ${var.model_name}
       <<: *permissions


### PR DESCRIPTION
- Update `-e` flag to `-t` given flag updates for `Databricks CLI v0.203.2`
- Update `models:` to `model-registry:` given [CLI command group change](https://learn.microsoft.com/en-us/azure/databricks/dev-tools/cli/databricks-cli-ref#cli-command-groups) 