### PR TITLE
Switch example staging and prod workspace URLs based on cloud provider

### DIFF
--- a/databricks_template_schema.json
+++ b/databricks_template_schema.json
@@ -27,14 +27,14 @@
     "input_databricks_staging_workspace_host": {
       "order": 5,
       "type": "string",
-      "default": "",
-      "description": "\nURL of staging Databricks workspace, used to run CI tests on PRs and preview config changes before they're deployed to production{{if eq .input_cloud `azure`}}.\nExample: https://adb-xxxx.xx.azuredatabricks.net{{else if eq .input_cloud `aws`}}.\nExample: https://your-staging-workspace.cloud.databricks.com{{end}}\n"
+      "default": "{{if eq .input_cloud `azure`}}https://adb-xxxx.xx.azuredatabricks.net{{else if eq .input_cloud `aws`}}https://your-staging-workspace.cloud.databricks.com{{end}}",
+      "description": "\nURL of staging Databricks workspace, used to run CI tests on PRs and preview config changes before they're deployed to production. Default"
     },
     "input_databricks_prod_workspace_host": {
       "order": 6,
       "type": "string",
-      "default": "",
-      "description": "\nURL of production Databricks workspace{{if eq .input_cloud `azure`}}.\nExample: https://adb-xxxx.xx.azuredatabricks.net{{else if eq .input_cloud `aws`}}.\nExample: https://your-prod-workspace.cloud.databricks.com{{end}}\n"
+      "default": "{{if eq .input_cloud `azure`}}https://adb-xxxx.xx.azuredatabricks.net{{else if eq .input_cloud `aws`}}https://your-prod-workspace.cloud.databricks.com{{end}}",
+      "description": "\nURL of production Databricks workspace. Default"
     },
     "input_default_branch": {
       "order": 7,

--- a/databricks_template_schema.json
+++ b/databricks_template_schema.json
@@ -28,13 +28,13 @@
       "order": 5,
       "type": "string",
       "default": "",
-      "description": "\nURL of staging Databricks workspace, used to run CI tests on PRs and preview config changes before they're deployed to production. Default: \nAzure - https://adb-xxxx.xx.azuredatabricks.net\nAWS - https://your-staging-workspace.cloud.databricks.com\n"
+      "description": "\nURL of staging Databricks workspace, used to run CI tests on PRs and preview config changes before they're deployed to production{{if eq .input_cloud `azure`}}.\nExample: https://adb-xxxx.xx.azuredatabricks.net{{else if eq .input_cloud `aws`}}.\nExample: https://your-staging-workspace.cloud.databricks.com{{end}}\n"
     },
     "input_databricks_prod_workspace_host": {
       "order": 6,
       "type": "string",
       "default": "",
-      "description": "\nURL of production Databricks workspace. Default: \nAzure - https://adb-xxxx.xx.azuredatabricks.net\nAWS - https://your-prod-workspace.cloud.databricks.com\n"
+      "description": "\nURL of production Databricks workspace{{if eq .input_cloud `azure`}}.\nExample: https://adb-xxxx.xx.azuredatabricks.net{{else if eq .input_cloud `aws`}}.\nExample: https://your-prod-workspace.cloud.databricks.com{{end}}\n"
     },
     "input_default_branch": {
       "order": 7,


### PR DESCRIPTION
## Changes
This PR parameterises the example host URLs displayed in prompts based on the cloud provider that a user selects.

Note, changes in this PR required a `min_cli_version` of v0.208.1. Do not merge until a correct minimum CLI version is set in the template schema.

## Tests
 Tested Manually.

