### PR TITLE
Add the minimum CLI version supported by the template

### DIFF
--- a/databricks_template_schema.json
+++ b/databricks_template_schema.json
@@ -1,10 +1,11 @@
 {
+  "min_databricks_cli_version": "v0.209.0",
   "properties": {
     "input_project_name": {
       "order": 1,
       "type": "string",
       "default": "my-mlops-project",
-      "description": "Welcome to MLOps Stacks. For detailed information on project generation, see the README at https://github.com/databricks/mlops-stacks/blob/main/README.md. \n\nProject Name"
+      "description": "{{if false}}\n\nERROR: This template is no longer supported supported by CLI version v0.209 and lower.\nPlease hit control-C and go to https://docs.databricks.com/en/dev-tools/cli/install.html for instructions on upgrading the CLI.\n\n\n{{end}}Welcome to MLOps Stacks. For detailed information on project generation, see the README at https://github.com/databricks/mlops-stacks/blob/main/README.md. \n\nProject Name"
     },
     "input_root_dir": {
       "order": 2,

--- a/databricks_template_schema.json
+++ b/databricks_template_schema.json
@@ -5,7 +5,7 @@
       "order": 1,
       "type": "string",
       "default": "my-mlops-project",
-      "description": "{{if false}}\n\nERROR: This template is no longer supported supported by CLI version v0.209 and lower.\nPlease hit control-C and go to https://docs.databricks.com/en/dev-tools/cli/install.html for instructions on upgrading the CLI.\n\n\n{{end}}Welcome to MLOps Stacks. For detailed information on project generation, see the README at https://github.com/databricks/mlops-stacks/blob/main/README.md. \n\nProject Name"
+      "description": "{{if false}}\n\nERROR: This template is no longer supported supported by CLI versions v0.209 and lower.\nPlease hit control-C and go to https://docs.databricks.com/en/dev-tools/cli/install.html for instructions on upgrading the CLI.\n\n\n{{end}}Welcome to MLOps Stacks. For detailed information on project generation, see the README at https://github.com/databricks/mlops-stacks/blob/main/README.md. \n\nProject Name"
     },
     "input_root_dir": {
       "order": 2,


### PR DESCRIPTION
This CLI adds minimum version of the CLI required to use the template. Newer features (eg: https://github.com/databricks/mlops-stacks/pull/112) used by the stack are not compantible with older CLI versions.

The CLI respects the `min_databricks_cli_version` metadata field and returns an error to the user.

Here's the output for a couple different CLI versions:
CLI version >= {min_databricks_cli_version} (in this case v0.209):
Works as expected
```
shreyas.goenka@THW32HFW6T playground % ./databricks_cli_0.209.0_darwin_arm64/databricks bundle init ~/mlops-stack
Welcome to MLOps Stacks. For detailed information on project generation, see the README at https://github.com/databricks/mlops-stacks/blob/main/README.md. 

Project Name [my-mlops-project]: ^C
```

CLI version < {min_databricks_cli_version} AND >= v0.208.2 (when support for min_databricks_cli_version was introduced)
```
shreyas.goenka@THW32HFW6T playground % ./databricks_cli_0.208.2_darwin_arm64/databricks bundle init ~/mlops-stack
Error: minimum CLI version "v0.209.0" is greater than current CLI version "v0.208.2". Please upgrade your current Databricks CLI
```

CLI version == v0.208.2
Unfortunately we don't have any method to display an error to the users of this version of the CLI. 

CLI version <= v0.208.1
Hacky solution to give warnings to users of older CLI versions. This is the best effort we can do. Once the CLI goes GA this hack can be reverted.
```
shreyas.goenka@THW32HFW6T playground % ./databricks_cli_0.208.0_darwin_arm64/databricks bundle init ~/mlops-stack
{{if false}}

ERROR: This template is no longer supported supported by CLI versions v0.209 and lower.
Please hit control-C and go to https://docs.databricks.com/en/dev-tools/cli/install.html for instructions on upgrading the CLI.


{{end}}Welcome to MLOps Stacks. For detailed information on project generation, see the README at https://github.com/databricks/mlops-stacks/blob/main/README.md. 

Project Name [my-mlops-project]: 
```