### PR TITLE
Update the version of matplotlib to avoid security issues

### DIFF
--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/requirements.txt.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/requirements.txt.tmpl
@@ -2,7 +2,8 @@ mlflow==2.7.1
 numpy>=1.23.0
 pandas==1.5.3
 scikit-learn>=1.1.1
-matplotlib>=3.8.4
+matplotlib>=3.5.2
+pillow>=10.0.1
 Jinja2==3.0.3
 pyspark~=3.3.0
 pytz~=2022.2.1

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/requirements.txt.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/requirements.txt.tmpl
@@ -2,7 +2,7 @@ mlflow==2.7.1
 numpy>=1.23.0
 pandas==1.5.3
 scikit-learn>=1.1.1
-matplotlib>=3.5.2
+matplotlib>=3.8.4
 Jinja2==3.0.3
 pyspark~=3.3.0
 pytz~=2022.2.1


### PR DESCRIPTION
Update the version of matplotlib to avoid security issues with the version of its required package Pillow. This way, the installed version of Pillow will be at least 10.3.0, which doesn't have the problematic security issue: https://security.snyk.io/vuln/SNYK-PYTHON-PILLOW-5918878