### PR TITLE
minor change to deploy.py.tmpl to fix the duplicated alias assigned to the created model in UC

### DIFF
--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/deployment/model_deployment/deploy.py.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/deployment/model_deployment/deploy.py.tmpl
@@ -41,7 +41,7 @@ def deploy(model_uri, env):
     _, model_name, version = model_uri.split("/")
     client = MlflowClient(registry_uri="databricks-uc")
     mv = client.get_model_version(model_name, version)
-    target_alias = "Champion"
+    target_alias = "champion"
     if target_alias not in mv.aliases:
         client.set_registered_model_alias(
             name=model_name,
@@ -49,12 +49,12 @@ def deploy(model_uri, env):
             version=version)
         print(f"Assigned alias '{target_alias}' to model version {model_uri}.")
         
-        # remove "Challenger" alias if assigning "Champion" alias
-        if target_alias == "Champion" and "Challenger" in mv.aliases:
-            print(f"Removing 'Challenger' alias from model version {model_uri}.")
+        # remove "challenger" alias if assigning "champion" alias
+        if target_alias == "champion" and "challenger" in mv.aliases:
+            print(f"Removing 'challenger' alias from model version {model_uri}.")
             client.delete_registered_model_alias(
                 name=model_name,
-                alias="Challenger")
+                alias="challenger")
 {{end}}
 
 


### PR DESCRIPTION
change all alias to lower case, mlflow UC model registry does not different upper/lower case in alias. The original code leads to model in UC have both alias "champion" and "challenger"
![image](https://github.com/databricks/mlops-stacks/assets/80770057/f71511c6-a13f-4c79-9d74-e557223551ed)
