### PR TITLE
Make monitoring initially optional to allow creation of inference tables first

### DIFF
--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/databricks.yml.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/databricks.yml.tmpl
@@ -15,7 +15,14 @@ include:
   # Resources folder contains ML artifact resources for the ML project that defines model and experiment
   # And workflows resources for the ML project including model training -> validation -> deployment,
   # {{- if (eq .input_include_feature_store `yes`) }} feature engineering, {{ end }} batch inference, quality monitoring, metric refresh, alerts and triggering retraining
-  - ./resources/*.yml
+  - ./resources/batch-inference-workflow-resource.yml
+  - ./resources/ml-artifacts-resource.yml
+  - ./resources/model-workflow-resource.yml
+  {{- if (eq .input_include_feature_store `yes`) }}
+  - ./resources/feature-engineering-workflow-resource.yml
+  {{- end }}
+  # TODO: uncomment once monitoring inference table has been created
+  # - ./resources/monitoring-resource.yml
 
 # Deployment Target specific values for workspace
 targets:

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/monitoring/README.md.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/monitoring/README.md.tmpl
@@ -1,5 +1,10 @@
 # Monitoring
 
-To enable monitoring as part of a scheduled Databricks workflow, please update all the TODOs in the [monitoring resource file](../resources/monitoring-resource.yml), and refer to
-[{{template `project_name_alphanumeric_underscore` .}}/resources/README.md](../resources/README.md). The implementation supports monitoring of batch inference tables directly.
+To enable monitoring as part of a scheduled Databricks workflow, please:
+- Create the inference table that you want to monitor and was passed in as an initialization parameter.
+- Update all the TODOs in the [monitoring resource file](../resources/monitoring-resource.yml).
+- Uncomment the monitoring workflow from the main Databricks Asset Bundles file [databricks.yml](../databricks.yml).
+
+For more details, refer to [{{template `project_name_alphanumeric_underscore` .}}/resources/README.md](../resources/README.md). 
+The implementation supports monitoring of batch inference tables directly.
 For real time inference tables, unpacking is required before monitoring can be attached.

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/resources/README.md.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/resources/README.md.tmpl
@@ -160,6 +160,7 @@ entry point then decides whether to execute the model retraining workflow.
 To set up and enable monitoring:
 * If it is not done already, generate inference table, join it with ground truth labels, and update the table name in [monitoring-resource.yml](./monitoring-resource.yml).
 * Resolve the `TODOs`  in [monitoring-resource.yml](./monitoring-resource.yml)
+* Uncomment the monitoring workflow in [databricks.yml](../databricks.yml)
 * OPTIONAL: Update the query in [metric_violation_check_query.py](../monitoring/metric_violation_check_query.py) to customize when the metric is considered to be in violation.
 
 NOTE: If ground truth labels are not available, you can still set up monitoring but should disable the retraining workflow.


### PR DESCRIPTION
We comment out the monitoring workflow initially to allow for creation of the inference tables first.