### PR TITLE
Fix self-referencing filename

### DIFF
--- a/template/{{.input_root_dir}}/.azure/devops-pipelines/{{.input_project_name}}-tests-ci.yml.tmpl
+++ b/template/{{.input_root_dir}}/.azure/devops-pipelines/{{.input_project_name}}-tests-ci.yml.tmpl
@@ -12,7 +12,7 @@ trigger:
   paths:
     include:
       - {{template `project_name_alphanumeric_underscore` .}}/*
-      - '.azure/devops-pipelines/{{ .input_project_name }}-run-tests.yml'
+      - '.azure/devops-pipelines/{{ .input_project_name }}-tests-ci.yml'
 
 variables:
   - name: workingDirectory


### PR DESCRIPTION
Cutting a PR based off of user report:

From my understanding, the following line is self referencing but the filename is incorrect. The current filename is `*-tests-ci.yml`. 

https://github.com/databricks/mlops-stacks/blob/267b1e5cda22623a392650cc82e4cea9d53fbaa3/template/%7B%7B.input_root_dir%7D%7D/.azure/devops-pipelines/%7B%7B.input_project_name%7D%7D-tests-ci.yml.tmpl#L15

Thus, the line should be updated to: 
```
 - '.azure/devops-pipelines/{{ .input_project_name }}-tests-ci.yml'
```