### PR TITLE
Updates to readme, and batch inference

### DIFF
--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/deployment/batch_inference/predict.py.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/deployment/batch_inference/predict.py.tmpl
@@ -29,18 +29,18 @@ def predict_batch(
     {{ end }}
     output_df = (
         prediction_df.withColumn("prediction", prediction_df["prediction"])
-        .withColumn("model_version", lit(model_version))
-        .withColumn("inference_timestamp", to_timestamp(lit(ts)))
+        .withColumn("model_id", lit(model_version))
+        .withColumn("timestamp", to_timestamp(lit(ts)))
     )
     {{ else }} 
     predict = mlflow.pyfunc.spark_udf(
-        spark_session, model_uri, result_type="string", env_manager="virtualenv"
+        spark_session, model_uri, result_type="double", env_manager="virtualenv"
     )    
     
     output_df = (
         table.withColumn("prediction", predict(struct(*table.columns)))
-        .withColumn("model_version", lit(model_version))
-        .withColumn("inference_timestamp", to_timestamp(lit(ts)))
+        .withColumn("model_id", lit(model_version))
+        .withColumn("timestamp", to_timestamp(lit(ts)))
     )
     {{ end -}}
     

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/resources/README.md.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/resources/README.md.tmpl
@@ -119,8 +119,32 @@ Follow the next section to configure the input and output data tables for the ba
 {{- end }}
 
 ### Setting up the batch inference job
-The batch inference job expects an input Delta table with a schema that your registered model accepts. To use the batch
+The batch inference job expects an input Delta table with a schema that your registered model accepts (trip_distance, pickup_zip and dropoff_zip). To use the batch
 inference job, set up such a Delta table in both your staging and prod workspaces.
+```
+# To test the batch job the training data can be used as input
+
+input_table_path = "/databricks-datasets/nyctaxi-with-zipcodes/subsampled"
+training_df = spark.read.format("delta").load(input_table_path)
+
+# drop unused columns
+df = df.drop("tpep_pickup_datetime", "tpep_dropoff_datetime")
+
+# target column used for monitoring, not for predictions
+df = df.withColumnRenamed('fare_amount', 'price')
+
+spark.sql("CREATE DATABASE IF NOT EXISTS my_catalog.my_schema")
+
+def write_to_table(df, database, table):
+  (df.write
+   .format("delta")
+   .mode("overwrite")
+   .option("overwriteSchema", "true")
+   .saveAsTable(f"{database}.{table}"))
+
+# Write the DataFrame to a Delta table
+write_to_table(training_df, database="my_catalog.my_schema", table="batch_input_table")
+```
 Following this, update the batch_inference_job base parameters in `{{template `project_name_alphanumeric_underscore` .}}/resources/batch-inference-workflow-resource.yml` to pass
 the name of the input Delta table and the name of the output Delta table to which to write batch predictions.
 

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/resources/README.md.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/resources/README.md.tmpl
@@ -119,8 +119,8 @@ Follow the next section to configure the input and output data tables for the ba
 {{- end }}
 
 ### Setting up the batch inference job
-The batch inference job expects an input Delta table with a schema that your registered model accepts (trip_distance, pickup_zip and dropoff_zip). To use the batch
-inference job, set up such a Delta table in both your staging and prod workspaces.
+The batch inference job expects an input Delta table with a schema that your registered model accepts (out-of-the-box we provide a working example using the `nyctaxi` dataset with the schema [trip_distance, pickup_zip and dropoff_zip]). To use the batch
+inference job, set up such a Delta table in both your staging and prod workspaces. For example, with the `nyctaxi` dataset, the following code can be run in a Databricks notebook to create the batch inference input table:
 ```
 # To test the batch job the training data can be used as input
 


### PR DESCRIPTION
Updated batch inference fields to match what is expected from the monitoring script Adding example of batch input table creation to the readme
monitoring-resource.yml expects model_id and timestamp and that predictions is not a string
