### PR TITLE
Pass python-version as string for GitHub Actions

### DIFF
--- a/.github/workflows/run-checks.yaml
+++ b/.github/workflows/run-checks.yaml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: '3.9'
       - name: Install act
         run: |
           # Install act

--- a/template/{{.input_root_dir}}/.github/workflows/{{.input_project_name}}-run-tests.yml.tmpl
+++ b/template/{{.input_root_dir}}/.github/workflows/{{.input_project_name}}-run-tests.yml.tmpl
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.10
+          python-version: '3.10'
       {{- if (eq .input_include_feature_store `yes`) }}
       # Feature store tests bring up a local Spark session, so Java is required.
       - uses: actions/setup-java@v4


### PR DESCRIPTION
Faced an error on a new instance of MLOps stacks where GitHub Actions was reading `python-version: 3.10` as `python-version: 3.1`.

<img width="1104" height="333" alt="image" src="https://github.com/user-attachments/assets/9a4d08ff-c0e3-4506-8a9e-eae47be9d6d3" />

Issue was fixed quoting the version number for it to be read as a string

[actions/setup-python@v5](https://github.com/actions/setup-python) provides their examples with quoted version numbers.

Preemptively updated the `run-checks` pipeline as the same issue may occur once upgraded to 3.10+
