### PR TITLE
Update MLFlow 3.0 Deprecated Variable "higher_is_better" to "greater_is_better"

### DIFF
--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/validation/validation.py.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/validation/validation.py.tmpl
@@ -23,13 +23,13 @@ def custom_metrics():
 def validation_thresholds():
     return {
         "max_error": MetricThreshold(
-            threshold=500, higher_is_better=False  # max_error should be <= 500
+            threshold=500, greater_is_better=False  # max_error should be <= 500
         ),
         "mean_squared_error": MetricThreshold(
             threshold=500,  # mean_squared_error should be <= 500
             # min_absolute_change=0.01,  # mean_squared_error should be at least 0.01 greater than baseline model accuracy
             # min_relative_change=0.01,  # mean_squared_error should be at least 1 percent greater than baseline model accuracy
-            higher_is_better=False,
+            greater_is_better=False,
         ),
     }
 


### PR DESCRIPTION
Issue: MLOps Stacks running MLFlow 3.0+ have the Validation.py file as being "higher_is_better", a deprecated and unexpected variable when run.

Note: Line 17 is already updated from "higher_is_better" to "greater_is_better" per MLFlow's documentation: https://mlflow.org/docs/latest/genai/mlflow-3/breaking-changes/