### PR TITLE
Add setuptools version constraint to dev-requirements

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
 pytest==7.4.4
 pytest-black
 mlflow==2.11.3
+setuptools<=81.0.0 # newer versions remove pkg_resources, which is required by mlflow


### PR DESCRIPTION
Added setuptools version constraint for compatibility with mlflow because newer versions remove pkg_resources, which is required by mlflow

Closes #215 