### PR TITLE
Harden CI/CD supply chain: pin references, verify downloads, scope tokens

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# Code owners for mlops-stacks.
+# Changes to CI/CD workflows and the security-sensitive test harness require
+# review from a code owner. Combine with branch protection ("Require review
+# from Code Owners") on the default branch to enforce.
+
+# CI/CD workflows — highest-value supply-chain surface.
+/.github/            @veenaramesh @alexbaur @sdonohoo-db
+/.github/workflows/  @veenaramesh @alexbaur @sdonohoo-db
+
+# Test harness that fetches and executes external tooling in CI.
+/tests/install.sh             @veenaramesh @alexbaur @sdonohoo-db
+/tests/test_github_actions.py @veenaramesh @alexbaur @sdonohoo-db
+
+# Dependency manifests.
+/dev-requirements.txt @veenaramesh @alexbaur @sdonohoo-db

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  # Keep GitHub Actions pinned to SHAs up to date (Dependabot updates the SHA
+  # and the trailing version comment together).
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  # Python dev/test dependencies.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "python"

--- a/.github/workflows/generate-cicd-zip.yaml
+++ b/.github/workflows/generate-cicd-zip.yaml
@@ -11,26 +11,35 @@ defaults:
   run:
     working-directory: template/{{.input_root_dir}}
 
+# Scoped to what the PR-creation flow needs; no long-lived PAT. The regenerated
+# tarball is proposed as a reviewable PR rather than pushed straight to main.
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   generate-zip:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Generate CICD Zip
         run: |
           cp --parents .github/workflows/\{\{.input_project_name\}\}-* cicd/template
           cp --parents .azure/devops-pipelines/\{\{.input_project_name\}\}-* cicd/template
           tar -czvf cicd.tar.gz cicd
-      - name: Commit Zip Back to Branch
-        env:
-          GITHUB_TOKEN: ${{ secrets.ARPIT_TOKEN }}
-        run: |
-          git config --global user.name "GitHub Actions Bot"
-          git config --global user.email "eng-mlops-outerloop-team@databricks.com"
-          git config --global url.https://${{ secrets.ARPIT_TOKEN }}@github.com/.insteadOf https://github.com/
-          git add cicd.tar.gz
-          git commit -m "Generate CICD Zip File for ${{ github.sha }}"
-          git push
+      - name: Open PR with regenerated CICD Zip
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          # Only the generated artifact; nothing else is committed.
+          add-paths: template/{{.input_root_dir}}/cicd.tar.gz
+          commit-message: "Generate CICD Zip File for ${{ github.sha }}"
+          branch: auto/regenerate-cicd-zip
+          delete-branch: true
+          title: "Regenerate CICD Zip for ${{ github.sha }}"
+          body: |
+            Automated regeneration of `cicd.tar.gz` triggered by changes to the
+            CI/CD template files in `${{ github.sha }}`.
+
+            Review the diff and merge to keep the checked-in artifact in sync.
+          committer: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+          author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"

--- a/.github/workflows/run-checks.yaml
+++ b/.github/workflows/run-checks.yaml
@@ -1,22 +1,33 @@
 name: Run checks
 on:
   pull_request:
+
+# Least-privilege default token: fork PRs only ever get read access.
+permissions:
+  contents: read
+
 jobs:
   run-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.9'
       - name: Install act
+        env:
+          # Pin act to a released version rather than fetching a mutable branch.
+          ACT_VERSION: v0.2.89
         run: |
-          # Install act
-          curl https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash
-          echo "-P ubuntu-latest=ghcr.io/catthehacker/ubuntu:act-latest
-          -P ubuntu-20.04=ghcr.io/catthehacker/ubuntu:act-20.04
-          -P ubuntu-18.04=ghcr.io/catthehacker/ubuntu:act-18.04" > ~/.actrc
-          echo "PATH=$PATH:$(pwd)/bin" >> "$GITHUB_ENV"
+          # Install act to a user-writable dir (no sudo) from a pinned release tag.
+          mkdir -p "$HOME/.local/bin"
+          curl -fsSL "https://raw.githubusercontent.com/nektos/act/${ACT_VERSION}/install.sh" -o /tmp/install-act.sh
+          bash /tmp/install-act.sh -b "$HOME/.local/bin" "$ACT_VERSION"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          # Pin runner container images to immutable digests.
+          echo "-P ubuntu-latest=ghcr.io/catthehacker/ubuntu:act-latest@sha256:5d6a17640b25694988b9db5a4145537b9918e5430116b2cf90d84e837609b382
+          -P ubuntu-20.04=ghcr.io/catthehacker/ubuntu:act-20.04@sha256:29b5352bd8a624bc3332299489548da8aa2831ca39a97a9bc760d27b77aa593a
+          -P ubuntu-18.04=ghcr.io/catthehacker/ubuntu:act-18.04@sha256:a037e34e5a70667384b4941c90618ac1567d7454de572ba0c4420a1cc38cbaa0" > ~/.actrc
       - name: Install Python dependencies
         run: |
             python -m pip install --upgrade pip

--- a/.github/workflows/run-checks.yaml
+++ b/.github/workflows/run-checks.yaml
@@ -16,13 +16,18 @@ jobs:
           python-version: '3.9'
       - name: Install act
         env:
-          # Pin act to a released version rather than fetching a mutable branch.
+          # Pinned release + known-good SHA256 of the release binary (no install
+          # script, no mutable branch). Runner is always ubuntu x86_64.
           ACT_VERSION: v0.2.89
+          ACT_TARBALL: act_Linux_x86_64.tar.gz
+          ACT_SHA256: 0191d6f1f3b716b5c55820032605d05fc3c1cdbf581ebeff655019e5dd1524c0
         run: |
-          # Install act to a user-writable dir (no sudo) from a pinned release tag.
           mkdir -p "$HOME/.local/bin"
-          curl -fsSL "https://raw.githubusercontent.com/nektos/act/${ACT_VERSION}/install.sh" -o /tmp/install-act.sh
-          bash /tmp/install-act.sh -b "$HOME/.local/bin" "$ACT_VERSION"
+          curl -fsSL -o /tmp/act.tar.gz \
+            "https://github.com/nektos/act/releases/download/${ACT_VERSION}/${ACT_TARBALL}"
+          echo "${ACT_SHA256}  /tmp/act.tar.gz" | sha256sum -c -
+          tar -xzf /tmp/act.tar.gz -C "$HOME/.local/bin" act
+          chmod +x "$HOME/.local/bin/act"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           # Pin runner container images to immutable digests.
           echo "-P ubuntu-latest=ghcr.io/catthehacker/ubuntu:act-latest@sha256:5d6a17640b25694988b9db5a4145537b9918e5430116b2cf90d84e837609b382

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 # local bundle files
 **/.databricks/*
+.local/
 
 *.hcl
 .idea/

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,5 @@
 pytest==7.4.4
-pytest-black
-mlflow>=3.1
+pytest-black==0.6.0
+# Intentionally tests against current MLflow 3.x; upper bound guards against a
+# breaking major-version bump landing silently in CI.
+mlflow>=3.1,<4

--- a/tests/install.sh
+++ b/tests/install.sh
@@ -55,8 +55,37 @@ fi
 # Change into test temporary directory.
 cd $1
 
+# Known-good SHA256 checksums for the v0.236.0 release archives.
+# Source: https://github.com/databricks/cli/releases/download/v0.236.0/databricks_cli_0.236.0_SHA256SUMS
+checksum_for() {
+    case "$1" in
+    databricks_cli_0.236.0_darwin_amd64.zip) echo "9d9740eea40f89b4186c8bd9b44caacaf6a56f91d8fce7ec10cabbfec67c9ee0" ;;
+    databricks_cli_0.236.0_darwin_arm64.zip) echo "fa1a945c2eaf9bc8d36d2eb7f0b394d1cfd4f4659d3de424ae7f82228ea7bd2e" ;;
+    databricks_cli_0.236.0_linux_amd64.zip)  echo "4e688a4e622dceb66c109544f5b13bf4cf900e429c7b6a83d1037f3e18387fcb" ;;
+    databricks_cli_0.236.0_linux_arm64.zip)  echo "7f15b96f609c9888566b5560c8c03c5f1ed20272763f28bc888ea533b8beea0c" ;;
+    databricks_cli_0.236.0_windows_amd64.zip) echo "ab5a0dcd5665b787410c9cca78f1181791a5c385d53862a5fa83d03c6b10c01d" ;;
+    databricks_cli_0.236.0_windows_arm64.zip) echo "a063ce7792fe31dd843a631d44a07c2f8a395f138a53e1d0e80df58c117d0310" ;;
+    *) echo "" ;;
+    esac
+}
+
 # Download release archive.
 curl -L -s -O "https://github.com/databricks/cli/releases/download/v${VERSION}/${FILE}.zip"
+
+# Verify the download against the known-good checksum before using it.
+EXPECTED_SHA="$(checksum_for "${FILE}.zip")"
+if [ -z "$EXPECTED_SHA" ]; then
+    echo "No known checksum for ${FILE}.zip; refusing to proceed."
+    exit 1
+fi
+if command -v sha256sum >/dev/null 2>&1; then
+    echo "${EXPECTED_SHA}  ${FILE}.zip" | sha256sum -c - || { echo "Checksum verification failed for ${FILE}.zip"; exit 1; }
+elif command -v shasum >/dev/null 2>&1; then
+    echo "${EXPECTED_SHA}  ${FILE}.zip" | shasum -a 256 -c - || { echo "Checksum verification failed for ${FILE}.zip"; exit 1; }
+else
+    echo "No sha256sum/shasum available to verify download."
+    exit 1
+fi
 
 # Unzip release archive.
 unzip -q "${FILE}.zip"

--- a/tests/test_github_actions.py
+++ b/tests/test_github_actions.py
@@ -1,4 +1,9 @@
+import hashlib
+import os
+import platform
 import subprocess
+import tarfile
+import urllib.request
 import pytest
 from functools import wraps
 from utils import (
@@ -6,6 +11,58 @@ from utils import (
     generated_project_dir,
     parametrize_by_cloud,
 )
+
+# Pinned actionlint release. The binary is verified against the known-good
+# SHA256 published in the release's checksums.txt before it is executed, so a
+# compromised/retagged upstream cannot inject code into CI.
+# Source: https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_checksums.txt
+ACTIONLINT_VERSION = "1.7.12"
+ACTIONLINT_SHA256 = {
+    "darwin_amd64": "5b44c3bc2255115c9b69e30efc0fecdf498fdb63c5d58e17084fd5f16324c644",
+    "darwin_arm64": "aba9ced2dee8d27fecca3dc7feb1a7f9a52caefa1eb46f3271ea66b6e0e6953f",
+    "linux_amd64": "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8",
+    "linux_arm64": "325e971b6ba9bfa504672e29be93c24981eeb1c07576d730e9f7c8805afff0c6",
+}
+
+
+def _actionlint_platform():
+    system = platform.system().lower()  # "linux" / "darwin"
+    machine = platform.machine().lower()
+    arch = {
+        "x86_64": "amd64",
+        "amd64": "amd64",
+        "arm64": "arm64",
+        "aarch64": "arm64",
+    }.get(machine)
+    if system not in ("linux", "darwin") or arch is None:
+        raise RuntimeError(f"Unsupported platform for actionlint: {system}/{machine}")
+    return f"{system}_{arch}"
+
+
+def _install_actionlint(dest_dir):
+    """Download the pinned actionlint release and verify its SHA256 before use."""
+    dest_dir = str(dest_dir)
+    key = _actionlint_platform()
+    expected = ACTIONLINT_SHA256[key]
+    tarball = f"actionlint_{ACTIONLINT_VERSION}_{key}.tar.gz"
+    url = (
+        f"https://github.com/rhysd/actionlint/releases/download/"
+        f"v{ACTIONLINT_VERSION}/{tarball}"
+    )
+    archive_path = os.path.join(dest_dir, tarball)
+    urllib.request.urlretrieve(url, archive_path)
+    with open(archive_path, "rb") as f:
+        actual = hashlib.sha256(f.read()).hexdigest()
+    if actual != expected:
+        raise RuntimeError(
+            f"actionlint checksum mismatch for {tarball}: "
+            f"expected {expected}, got {actual}"
+        )
+    with tarfile.open(archive_path) as tf:
+        tf.extract("actionlint", path=dest_dir)
+    binary = os.path.join(dest_dir, "actionlint")
+    os.chmod(binary, 0o755)
+    return binary
 
 
 @pytest.mark.parametrize(
@@ -26,18 +83,15 @@ from utils import (
 def test_generated_yaml_format(cloud, generated_project_dir):
     # Note: actionlint only works when the directory is a git project. Thus we begin by initiatilizing
     # the generated mlops project with git.
-    # Pin actionlint to a released tag (not the mutable `main` branch) and pass the
-    # matching version to the downloader so the fetched binary is reproducible.
+    project_dir = generated_project_dir / "my-mlops-project"
+    # Install a pinned, checksum-verified actionlint instead of piping a script
+    # fetched from a mutable branch straight into bash.
+    actionlint = _install_actionlint(generated_project_dir)
+    subprocess.run("git init", shell=True, check=True, cwd=project_dir)
     subprocess.run(
-        """
-        git init
-        bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash) 1.7.12
-        ./actionlint -color
-        """,
-        shell=True,
+        [str(actionlint), "-color"],
         check=True,
-        executable="/bin/bash",
-        cwd=(generated_project_dir / "my-mlops-project"),
+        cwd=project_dir,
     )
 
 

--- a/tests/test_github_actions.py
+++ b/tests/test_github_actions.py
@@ -26,10 +26,12 @@ from utils import (
 def test_generated_yaml_format(cloud, generated_project_dir):
     # Note: actionlint only works when the directory is a git project. Thus we begin by initiatilizing
     # the generated mlops project with git.
+    # Pin actionlint to a released tag (not the mutable `main` branch) and pass the
+    # matching version to the downloader so the fetched binary is reproducible.
     subprocess.run(
         """
         git init
-        bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+        bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash) 1.7.12
         ./actionlint -color
         """,
         shell=True,


### PR DESCRIPTION
## Summary

Hardens the two repository GitHub Actions workflows following a CI/CD supply-chain review. The goal is to make it safe to (re-)enable Actions on this public repo by eliminating mutable external code paths, removing a long-lived credential, and applying least privilege — without changing what the workflows functionally do.

The review confirmed the good baseline first: **no `pull_request_target`, no `issue_comment`/`workflow_run` triggers, no self-hosted runners, no npm dependencies.** So fork PRs already run on ephemeral GitHub-hosted runners with a read-only token and no secrets. The remaining risk was **mutable-reference supply chain**, which this PR closes.

## Changes

**`.github/workflows/run-checks.yaml`** (CI)
- Add least-privilege `permissions: contents: read`.
- SHA-pin `actions/checkout` and `actions/setup-python`.
- Replace `curl .../nektos/act/master/install.sh | sudo bash` (mutable branch, run as root) with a direct download of the pinned **`act v0.2.89`** release tarball, **verified by SHA256**, installed to a user dir (no sudo).
- Pin the three `catthehacker/ubuntu` runner images to `@sha256:` digests.

**`.github/workflows/generate-cicd-zip.yaml`** (artifact regeneration)
- Remove the long-lived PAT **`ARPIT_TOKEN`**; use the built-in `GITHUB_TOKEN`.
- Instead of pushing the regenerated `cicd.tar.gz` straight to `main`, **open a reviewable PR** via SHA-pinned `peter-evans/create-pull-request@v8.1.1`. This composes cleanly with branch protection — no bot bypass required.
- SHA-pin `actions/checkout`; scope `permissions` to `contents: write` + `pull-requests: write`.

**`tests/test_github_actions.py`**
- Replace `bash <(curl .../rhysd/actionlint/main/...)` (mutable branch piped to bash) with a helper that downloads the pinned **`actionlint v1.7.12`** release for the host platform and **verifies its SHA256** before executing.

**`tests/install.sh`**
- Verify the downloaded Databricks CLI archive against a known-good **SHA256** before unzip.

**`dev-requirements.txt`**
- Pin `pytest-black==0.6.0`; bound `mlflow>=3.1,<4`.

**New governance files**
- `.github/CODEOWNERS` — require code-owner review for `.github/**`, the CI test harness, and manifests.
- `.github/dependabot.yml` — weekly updates for `github-actions` and `pip` (keeps SHA pins current).

## Supply-chain questionnaire (post-change)

| Question | Answer |
|---|---|
| Uses `pull_request` / `pull_request_target`? | `pull_request` yes; `pull_request_target` **no** |
| All actions on self-hosted runners? | **No** — all GitHub-hosted `ubuntu-latest` |
| npm dependencies? | **No** |
| PyPI dependencies? | Yes (`pytest`, `pytest-black` pinned; `mlflow` bounded `<4`) |
| Other 3P deps pinned to a known-good SHA? | **Yes** — act, actionlint, Databricks CLI SHA256-verified; runner images digest-pinned |
| GitHub Actions pinned to a SHA? | **Yes** — all references full-SHA pinned |

## Companion repo settings (already applied, verified via API)
- `ARPIT_TOKEN` secret deleted.
- "Allow GitHub Actions to create and approve pull requests" enabled (needed for the PR-based regeneration workflow).
- Branch protection on `main`: required `run-tests` check (strict), 1 approval, code-owner review, dismiss stale approvals, enforce admins.

## Testing
- All workflow YAML validated.
- `tests/test_github_actions.py` compiles; the platform/checksum helper resolves correctly for `linux_amd64` (CI) and `darwin_arm64` (local).
- No behavioral change to what the workflows produce.

This pull request and its description were written by Isaac.